### PR TITLE
Updated to mysql2 version 0.3.12b6.

### DIFF
--- a/ext/mysql_blob_streaming/mysql_blob_streaming.c
+++ b/ext/mysql_blob_streaming/mysql_blob_streaming.c
@@ -7,9 +7,11 @@
 
 typedef struct {
   VALUE encoding;
-  int active;
+  VALUE active_thread;
   int reconnect_enabled;
-  int closed;
+  int active;
+  int connected;
+  int initialized;
   MYSQL *client;
 } mysql_client_wrapper;
 

--- a/mysql_blob_streaming.gemspec
+++ b/mysql_blob_streaming.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.license = 'MIT'
 
-  spec.add_dependency('mysql2', '0.3.11')
+  spec.add_dependency('mysql2', '0.3.12b6')
   spec.required_ruby_version = '>=1.8.7'
 
   spec.files = Dir["lib/**/*.rb", "ext/**/*.{c,h,rb}", "README.markdown"]


### PR DESCRIPTION
This contains an important bugfix, so that timeouts of c mysql are correctly used. More details see https://github.com/brianmario/mysql2/pull/287 .

This is an issue with AWS RDS, which once in a while delays queries up to 15 minutes. Details see https://forums.aws.amazon.com/thread.jspa?messageID=446622&tstart=0https://forums.aws.amazon.com/thread.jspa?threadID=122020&tstart=0 and https://forums.aws.amazon.com/thread.jspa?threadID=122035&tstart=0

Bugfix requested by @anne-schulz .

I would suggest to release a new version with version number `2.0.12b6` to reflect the usage of a beta version.
