### PR TITLE
Feature/mysql 5.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 Makefile
 mkmf.log
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0.0"
-  - "2.1.3"
+  - "2.1.5"
   # - jruby-18mode # JRuby in 1.8 mode
   # - jruby-19mode # JRuby in 1.9 mode
   # - rbx-18mode

--- a/mysql_blob_streaming.gemspec
+++ b/mysql_blob_streaming.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.license = 'MIT'
 
-  spec.add_dependency('mysql2', '0.3.16')
+  spec.add_dependency 'mysql2', '>= 0.3.16', '< 0.4.0'
   spec.required_ruby_version = '>=1.9.3'
 
   spec.files = Dir["lib/**/*.rb", "ext/**/*.{c,h,rb}", "README.markdown"]

--- a/mysql_blob_streaming.gemspec
+++ b/mysql_blob_streaming.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
 
   spec.add_dependency 'mysql2', '>= 0.3.16', '< 0.4.0'
-  spec.required_ruby_version = '>=1.9.3'
+  spec.required_ruby_version = '>=2.0.0'
 
   spec.files = Dir["lib/**/*.rb", "ext/**/*.{c,h,rb}", "README.markdown"]
   spec.extensions = ['ext/mysql_blob_streaming/extconf.rb']

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,5 +1,10 @@
 # encoding: UTF-8
 require 'active_record'
+require 'active_record/connection_adapters/mysql2_adapter'
+
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end
 
 module Fixtures
   MY_DIR = File.dirname(__FILE__)


### PR DESCRIPTION
Allow other versions for `mysql2` to support MySQL 5.7. Supported with `0.3.18`.
Only allow `mysql2 < 0.4.0` for now to keep it a small change.